### PR TITLE
adds -upload-local-plugins pushconfig option to support uploading loc…

### DIFF
--- a/lib/tfe/commands/pushconfig
+++ b/lib/tfe/commands/pushconfig
@@ -32,6 +32,13 @@ list_modules () {
     find -L .terraform/modules -type f |  grep -E -v '^\.$|\.git'
 }
 
+list_local_plugins () {
+    test -d terraform.d
+    if [ $? -eq 0 ]; then
+      find -L terraform.d -type f |  grep -E -v '^\.$|\.git'
+    fi
+}
+
 list_hardlinked () {
     find -L . -type f -links +1 | grep -E -v '^\.$|.git|.terraform' | cut -c 3-
 }
@@ -60,6 +67,10 @@ gnutar () {
 
     if [ true = $upload_modules ]; then
         list_modules >> "$tarlist"
+    fi
+
+    if [ true = $upload_local_plugins ]; then
+        list_local_plugins >> "$tarlist"
     fi
 
     tar ${tfe_tar_verbose}zcfh \
@@ -93,6 +104,10 @@ bsdtar () {
 
         if [ true = $upload_modules ]; then
             list_modules >> "$tarlist"
+        fi
+
+        if [ true = $upload_local_plugins ]; then
+            list_local_plugins >> "$tarlist"
         fi
 
         tar ${tfe_tar_verbose}zcfh \
@@ -161,6 +176,13 @@ $(tfe_usage_args)
                       "version" parameter in provider blocks in the
                       configuration to accomplish that.
 
+-upload-local-plugins <BOOLEAN>
+                      If true, then the local plugins expected by Terraform Cloud
+                      located in the root of the configuration repo/terraform.d are
+                      uploaded along with the configuration. This will pin the provider
+                      version to the one that exists locally and must be found when terraform
+                      init is run in Terraform Cloud
+
  -vcs <BOOLEAN>       If true (default), push will upload only files
                       committed to your VCS, if detected. Currently supports
                       git repositories.
@@ -176,6 +198,7 @@ EOF
 
 tfe_pushconfig () (
     upload_modules=true
+    upload_local_plugins=false
     vcs=true
     config_dir=.
     poll_run=0
@@ -229,6 +252,20 @@ tfe_pushconfig () (
                         ;;
                     *)
                         echoerr "-upload-modules should be true or false"
+                        return 1
+                        ;;
+                esac
+                ;;
+            -upload-local-plugins)
+                case "$2" in
+                    true)
+                        upload_local_plugins=true
+                        ;;
+                    false)
+                        upload_local_plugins=false
+                        ;;
+                    *)
+                        echoerr "upload-local-plugins should be true or false"
                         return 1
                         ;;
                 esac


### PR DESCRIPTION
TFE purposely excludes local plugins because it is geared toward Terraform Enterprise and the expectation that all workspaces are linked with VCS repositories where the local plugin can be added as a submodule or included with the repo.

Since we are operating outside of these bounds this command adds the capability to add local plugins in the specific directory of $CONFIG_ROOT/terraform.d  (recursively). So a plugin living in $CONFIG_ROOT/terraform.d/plugins/linux_amd64/ will be included with the upload where Terraform Cloud can discover it.